### PR TITLE
Handle basic greeting in Lex chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sam deploy --guided
 
 ## Usage
 
-Once deployed, you can interact with the chatbot through the AWS Lex console or by integrating it with your applications.
+Once deployed, you can interact with the chatbot through the AWS Lex console or by integrating it with your applications. The current Lambda handler responds to common greetings with a short cultural or historical fact and otherwise encourages users to ask about world history.
 
 ## Contributing
 

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -1,20 +1,39 @@
+"""Lambda handler for the AWS Lex chatbot."""
+
+from __future__ import annotations
+
 import json
 
-def lambda_handler(event, context):
+
+def lambda_handler(event: dict, context) -> dict:
+    """Return a simple Lex Close dialog action.
+
+    The handler inspects the incoming event's ``inputTranscript`` and returns a
+    cultural or historical fact when a greeting is detected. For any other
+    input, a generic prompt encouraging the user to ask about history is
+    returned.
     """
-    Main Lambda handler function.
-    """
-    # TODO: Implement your chatbot logic here
-    
+
+    transcript = event.get("inputTranscript", "").lower()
+
+    if any(greeting in transcript for greeting in ("hello", "hi")):
+        message_content = (
+            "Hello! Did you know the first modern Olympic Games were held in 1896"
+            " in Athens?"
+        )
+    else:
+        message_content = "Thanks for your message! Ask me about world history."
+
     response = {
         "dialogAction": {
             "type": "Close",
             "fulfillmentState": "Fulfilled",
             "message": {
                 "contentType": "PlainText",
-                "content": "Hello from your Lex Chatbot!"
-            }
+                "content": message_content,
+            },
         }
     }
-    
+
     return response
+

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -1,38 +1,54 @@
-import json
+"""Unit tests for the Lambda handler."""
+
 import unittest
+
 from src import lambda_function
 
-class TestLambdaFunction(unittest.TestCase):
 
-    def test_lambda_handler(self):
-        # Create a sample event
-        event = {
+class TestLambdaFunction(unittest.TestCase):
+    """Tests for :func:`lambda_function.lambda_handler`."""
+
+    def _base_event(self, transcript: str) -> dict:
+        return {
             "currentIntent": {
                 "name": "LexChatbotIntent",
                 "slots": {},
-                "confirmationStatus": "None"
+                "confirmationStatus": "None",
             },
             "bot": {
                 "name": "LexChatbot",
                 "alias": "$LATEST",
-                "version": "$LATEST"
+                "version": "$LATEST",
             },
             "userId": "test_user",
-            "inputTranscript": "Hello",
+            "inputTranscript": transcript,
             "invocationSource": "FulfillmentCodeHook",
             "outputDialogMode": "Text",
             "messageVersion": "1.0",
-            "sessionAttributes": {}
+            "sessionAttributes": {},
         }
-        
-        # Call the lambda handler
-        context = {}
-        response = lambda_function.lambda_handler(event, context)
-        
-        # Check the response
-        self.assertEqual(response['dialogAction']['type'], 'Close')
-        self.assertEqual(response['dialogAction']['fulfillmentState'], 'Fulfilled')
-        self.assertEqual(response['dialogAction']['message']['content'], 'Hello from your Lex Chatbot!')
 
-if __name__ == '__main__':
+    def test_greeting_response(self) -> None:
+        event = self._base_event("Hello")
+        response = lambda_function.lambda_handler(event, {})
+
+        self.assertEqual(response["dialogAction"]["type"], "Close")
+        self.assertEqual(response["dialogAction"]["fulfillmentState"], "Fulfilled")
+        self.assertIn("Olympic Games", response["dialogAction"]["message"]["content"])
+
+    def test_generic_response(self) -> None:
+        event = self._base_event("Tell me a fact")
+        response = lambda_function.lambda_handler(event, {})
+
+        self.assertEqual(response["dialogAction"]["type"], "Close")
+        self.assertEqual(response["dialogAction"]["fulfillmentState"], "Fulfilled")
+        self.assertTrue(
+            response["dialogAction"]["message"]["content"].startswith(
+                "Thanks for your message"
+            )
+        )
+
+
+if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- respond to greetings with a historical fact in Lambda handler
- add unit tests for greeting and generic messages
- document greeting behavior in README

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d7bedcc83288687742b0ade8e41