### PR TITLE
Add testing suite reflection and expand lambda tests

### DIFF
--- a/REFLECTION.md
+++ b/REFLECTION.md
@@ -1,0 +1,66 @@
+# AI Testing Suite Reflection
+
+This document captures insights from a five-part banking chatbot testing suite.
+
+## 1. Prompt Quality Assessment
+
+- **Clarity** – The greeting and balance inquiry prompts were clear; the transfer and
+  context-management prompts needed more explicit slot/confirmation examples.
+- **Scope** – The fallback prompt was narrow, while the transaction prompt risked being
+  overly broad without stated limits.
+- **Progression** – Difficulty increased logically from greeting to multi-step transfers,
+  though the jump to advanced context handling was abrupt.
+- **Completeness** – Prompts could better specify error handling, authentication, and
+  expected response formatting.
+
+## 2. Testing Effectiveness
+
+- **Coverage** – The suite exercises intent routing, slot management, confirmation logic,
+  and basic error handling but lacks tests for persistence and scalability concerns.
+- **Real-world Relevance** – Scenarios mirror common banking tasks yet omit compliance
+  and security considerations present in production chatbots.
+- **Discrimination** – Prompts differentiate beginner from intermediate skill levels;
+  advanced reasoning (e.g., fraud detection) remains untested.
+- **Bias Detection** – Examples assume a single user profile and English language,
+  leaving regional or accessibility biases unexamined.
+
+## 3. Educational Value
+
+- **Learning Progression** – Concepts build sequentially, introducing intents, slots,
+  confirmation, and fallback strategies.
+- **Practical Application** – Skills transfer to other chatbot domains, especially those
+  requiring transactional workflows.
+- **Industry Alignment** – Prompts align with current serverless chatbot practices but
+  could expand to cover monitoring and compliance.
+- **Knowledge Gaps** – Underrepresented topics include localization, data retention, and
+  security auditing.
+
+## 4. Improvement Recommendations
+
+| Prompt | Refinements | Additional Constraints | Alternative Scenario | Evaluation Criteria |
+|-------|-------------|-----------------------|----------------------|--------------------|
+| 1. Greeting | Clarify expected personalization fields | Require session attribute persistence | Multi-language greeting | Check presence of user name and locale |
+| 2. Balance Inquiry | Specify account types and error messages | Validate numeric formatting | Add insufficient-funds case | Assert correct balance and errors |
+| 3. Transfer | Outline confirmation flow in detail | Limit transfer amount to positive values | Scheduled transfers | Verify balance updates and confirmations |
+| 4. Fallback | Define recovery strategies | Enforce neutral, helpful tone | Offer help-menu intent | Confirm suggested re-prompting |
+| 5. Context Management | Detail session memory expectations | Cap session history length | Cross-session recall | Measure context retention accuracy |
+
+## 5. Meta-Learning Insights
+
+- **Process Efficiency** – Template-based event builders speed test creation.
+- **Scalability** – The approach can adapt to other domains by swapping domain-specific
+  intents and slots.
+- **Version Control** – Iterate via small commits that pair new prompts with dedicated
+  tests.
+- **Success Metrics** – Track test pass rate, coverage of intents/slots, and alignment
+  with real banking user stories.
+
+## 6. Critical Analysis
+
+- **Assumptions** – The suite assumes reliable authentication and stable account data.
+- **Edge Cases** – Missing slot values or malformed amounts could break flows.
+- **Context Dependencies** – Different LLMs may interpret confirmation or slot values
+  inconsistently.
+- **Ethical Considerations** – Testing should respect privacy and avoid reinforcing
+  financial biases or exclusionary language.
+


### PR DESCRIPTION
## Summary
- add REFLECTION.md capturing insights from five-part banking chatbot testing suite
- rewrite lambda handler tests to cover greeting, balance inquiry, transfers, fallback, and auth failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aed1b7e5d483288e7f33742dc506b2